### PR TITLE
Update _helpers.tpl

### DIFF
--- a/charts/langfuse/templates/_helpers.tpl
+++ b/charts/langfuse/templates/_helpers.tpl
@@ -283,7 +283,7 @@ Get value of a specific environment variable from additionalEnv if it exists
 {{- if $.Values.clickhouse.replicaCount | int | eq 1 -}}
 - name: CLICKHOUSE_CLUSTER_ENABLED
   value: "false"
-{{- end -}}
+{{- end }}
 - name: LANGFUSE_AUTO_CLICKHOUSE_MIGRATION_DISABLED
   value: {{ not .Values.clickhouse.migration.autoMigrate | quote }}
 {{- end -}}


### PR DESCRIPTION
Fix helm template rendering problem

When using helm template the following error occurs:
```
Error: YAML parse error on langfuse/templates/web/deployment.yaml: error converting YAML to JSON: yaml: line 76: block sequence entries are not allowed in this context
```